### PR TITLE
Add Initial Particle TTree

### DIFF
--- a/include/RootFileWriter.hh
+++ b/include/RootFileWriter.hh
@@ -124,8 +124,10 @@ private:
     // TTrees //
     TTree* targetExit                                                           = NULL;
     TTree* trackerHits                                                          = NULL;
+    TTree* initParts                                                            = NULL;//EDF added 1 Mar 2023
     trackerHitStruct targetExitBuffer;
     trackerHitStruct trackerHitsBuffer;
+    trackerHitStruct initPartsBuffer; //EDF added 1 Mar 2023
 
     Double_t* magnetEdepsBuffer                                                 = NULL;
     TTree* magnetEdeps                                                          = NULL;

--- a/include/RootFileWriter.hh
+++ b/include/RootFileWriter.hh
@@ -127,7 +127,7 @@ private:
     TTree* initParts                                                            = NULL;//EDF added 1 Mar 2023
     trackerHitStruct targetExitBuffer;
     trackerHitStruct trackerHitsBuffer;
-    trackerHitStruct initPartsBuffer; //EDF added 1 Mar 2023
+    trackerHitStruct initPartsBuffer; //EDF added 1 Mar 2022
 
     Double_t* magnetEdepsBuffer                                                 = NULL;
     TTree* magnetEdeps                                                          = NULL;

--- a/src/RootFileWriter.cc
+++ b/src/RootFileWriter.cc
@@ -181,6 +181,10 @@ void RootFileWriter::initializeRootFile(){
                                "x/D:y:z:px:py:pz:E:PDG/I:charge:eventID");
         }
 
+        initParts = new TTree("InitParts","InitParts tree"); //EDF added 1 Mar 2023
+        initParts->Branch("InitPartsBranch",&initPartsBuffer,
+                            "x/D:y:z:px:py:pz:E"); //EDF added 1 Mar 2023
+
         trackerHits = new TTree("TrackerHits","TrackerHits tree");
         trackerHits->Branch("TrackerHitsBranch", &trackerHitsBuffer,
                             "x/D:y:z:px:py:pz:E:PDG/I:charge:eventID");
@@ -1180,6 +1184,19 @@ void RootFileWriter::doEvent(const G4Event* event){
     init_phasespaceY->Fill(genAct->y/mm,genAct->yp/rad);
     init_phasespaceXY->Fill(genAct->x/mm,genAct->y/mm);
     init_E->Fill(genAct->E/MeV);
+
+    //Fill the TTree
+    if (not miniFile) {
+        initPartsBuffer.x = genAct->x/mm;
+        initPartsBuffer.y = genAct->y/mm;
+
+        initPartsBuffer.px = genAct->xp/rad;
+        initPartsBuffer.py = genAct->yp/rad;
+
+        initPartsBuffer.E = genAct->E / MeV; //not sure this will work
+
+        initParts->Fill();
+    }
 
     // *** Data from Magnets, which use a TargetSD ***
     size_t magIdx = -1;

--- a/src/RootFileWriter.cc
+++ b/src/RootFileWriter.cc
@@ -181,9 +181,9 @@ void RootFileWriter::initializeRootFile(){
                                "x/D:y:z:px:py:pz:E:PDG/I:charge:eventID");
         }
 
-        initParts = new TTree("InitParts","InitParts tree"); //EDF added 1 Mar 2023
+        initParts = new TTree("InitParts","InitParts tree"); //EDF added 1 Mar 2022
         initParts->Branch("InitPartsBranch",&initPartsBuffer,
-                            "x/D:y:px:py:E"); //EDF added 1 Mar 2023
+                            "x/D:y:z:px:py:pz:E:PDG/I:charge:eventID"); //EDF added 1 Mar 2022
 
         trackerHits = new TTree("TrackerHits","TrackerHits tree");
         trackerHits->Branch("TrackerHitsBranch", &trackerHitsBuffer,
@@ -1189,11 +1189,18 @@ void RootFileWriter::doEvent(const G4Event* event){
     if (not miniFile) {
         initPartsBuffer.x = genAct->x/mm;
         initPartsBuffer.y = genAct->y/mm;
+        initPartsBuffer.z = genAct->z/mm; //Required to fill struct properly
 
-        initPartsBuffer.px = genAct->xp/rad;
+        initPartsBuffer.px = genAct->xp/rad; //Actually rad here
         initPartsBuffer.py = genAct->yp/rad;
+        initPartsBuffer.pz = 0;
 
-        initPartsBuffer.E = genAct->E / MeV; //not sure this will work
+        initPartsBuffer.E = genAct->E / MeV;
+
+        initPartsBuffer.PDG = 0; //filler until genAct is updated
+        initPartsBuffer.charge = 0;
+
+        initPartsBuffer.eventID = eventCounter;
 
         initParts->Fill();
     }
@@ -1729,6 +1736,7 @@ void RootFileWriter::finalizeRootFile() {
 
     if (not miniFile) {
         G4cout << "Writing TTrees..." << G4endl;
+        initParts->Write(); //writing InitParts with other TTrees
 
         if (detCon->GetHasTarget()) {
             targetExit->Write();

--- a/src/RootFileWriter.cc
+++ b/src/RootFileWriter.cc
@@ -183,7 +183,7 @@ void RootFileWriter::initializeRootFile(){
 
         initParts = new TTree("InitParts","InitParts tree"); //EDF added 1 Mar 2023
         initParts->Branch("InitPartsBranch",&initPartsBuffer,
-                            "x/D:y:z:px:py:pz:E"); //EDF added 1 Mar 2023
+                            "x/D:y:px:py:E"); //EDF added 1 Mar 2023
 
         trackerHits = new TTree("TrackerHits","TrackerHits tree");
         trackerHits->Branch("TrackerHitsBranch", &trackerHitsBuffer,


### PR DESCRIPTION
Added lines in RootFileWriter.hh to declare new TTree and HitStruct.
Followed structure format in RootFileWriter.cc. Only has 0s for PDG and charge, which Kyrre said this can be adjusted after he adds those sections to the GenAct function.
Confirmed it compiles and produces logical data on 8 March 2022.