### PR TITLE
Stop on overlaps

### DIFF
--- a/include/MiniScatterVersion.hh
+++ b/include/MiniScatterVersion.hh
@@ -1,0 +1,7 @@
+#ifndef MINISCATTERVERSION_HH
+#define MINISCATTERVERSION_HH 1
+
+inline const char* const miniscatter_version = "1.0";
+inline const char* const miniscatter_date    = "August 2022";
+
+#endif

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -46,6 +46,8 @@
 #include "G4SystemOfUnits.hh"
 #include "G4RunManager.hh"
 
+#include "G4Exception.hh"
+
 #include <cmath>
 #include <string>
 
@@ -189,7 +191,10 @@ G4VPhysicalVolume* DetectorConstruction::Construct() {
                                           logicWorld,                     //its mother
                                           false,                          //pMany not used
                                           0,                              //copy number
-                                          true);                          //Check for overlaps
+                                          false);                         //Check for overlaps
+        if(physiTarget->CheckOverlaps()) {
+            G4Exception("DetectorConstruction::Construct()", "MSDetCon1000",FatalException,"Overlap detected when placing Target, see error message above for more info.");
+        }
     }
     else {
         solidTarget = NULL;
@@ -217,8 +222,12 @@ G4VPhysicalVolume* DetectorConstruction::Construct() {
                                                           logicWorld,
                                                           false,
                                                           0,
-                                                          true);
+                                                          false);
 
+        if(magnetPV->CheckOverlaps()) {
+            G4String errormessage = "Overlap detected when placing magnet '" + magnet->magnetName + "', see error message above for more info.";
+            G4Exception("DetectorConstruction::Construct()", "MSDetCon1001",FatalException,errormessage);
+        }
         magnetPVs.push_back(magnetPV);
     }
 

--- a/src/DetectorConstruction.cc
+++ b/src/DetectorConstruction.cc
@@ -225,9 +225,12 @@ G4VPhysicalVolume* DetectorConstruction::Construct() {
                                                           false);
 
         if(magnetPV->CheckOverlaps()) {
-            G4String errormessage = "Overlap detected when placing magnet '" + magnet->magnetName + "', see error message above for more info.";
+            G4String errormessage = "Overlap detected when placing magnet \n"
+                "\t'" + magnet->magnetName + "' of type '" + magnet->magnetType + "'\n"
+                "\t, see error message above for more info.";
             G4Exception("DetectorConstruction::Construct()", "MSDetCon1001",FatalException,errormessage);
         }
+
         magnetPVs.push_back(magnetPV);
     }
 

--- a/src/MagnetCOLLIMATOR1.cc
+++ b/src/MagnetCOLLIMATOR1.cc
@@ -109,15 +109,21 @@ void MagnetCOLLIMATOR1::Construct() {
     }
 
     G4LogicalVolume*   absorberLV = new G4LogicalVolume(absorberSolid,absorberMaterial, magnetName+"_absorberLV");
-    //G4VPhysicalVolume* absorberPV =
-                                    new G4PVPlacement  (NULL,
+    G4VPhysicalVolume* absorberPV = new G4PVPlacement  (NULL,
                                                         G4ThreeVector(0.0,0.0,0.0),
                                                         absorberLV,
                                                         magnetName + "_absorberPV",
                                                         mainLV,
                                                         false,
                                                         0,
-                                                        true);
+                                                        false);
+
+    if(absorberPV->CheckOverlaps()) {
+        G4String errormessage = "Overlap detected when placing absorberPV for magnet \n"
+            "\t'" + magnetName + "' of type '" + magnetType + "'\n"
+            "\t, see error message above for more info.";
+        G4Exception("MagnetCOLLIMATOR1::Construct()", "MSDetConMagnet1001",FatalException,errormessage);
+    }
 
     ConstructDetectorLV();
     BuildMainPV_transform();

--- a/src/MagnetCOLLIMATORHV.cc
+++ b/src/MagnetCOLLIMATORHV.cc
@@ -118,22 +118,37 @@ void MagnetCOLLIMATORHV::Construct() {
     G4LogicalVolume*   targetMinLV = new G4LogicalVolume(jawMin,targetMaterial, magnetName+"_targetMinLV");
     
     G4double offset = gap/2+jawThick/2;
-    new G4PVPlacement  (NULL,
-                        G4ThreeVector(isH?offset:0.0,isH?0.0:offset,0.0),
-                        targetPluLV,
-                        magnetName + "_targetPluPV",
-                        mainLV,
-                        false,
-                        0,
-                        true);
-    new G4PVPlacement  (NULL,
-                        G4ThreeVector(isH?-offset:0.0,isH?0.0:-offset,0.0),
-                        targetMinLV,
-                        magnetName + "_targetMinPV",
-                        mainLV,
-                        false,
-                        0,
-                        true);
+
+    G4PVPlacement* targetPluPV =
+        new G4PVPlacement  (NULL,
+                            G4ThreeVector(isH?offset:0.0,isH?0.0:offset,0.0),
+                            targetPluLV,
+                            magnetName + "_targetPluPV",
+                            mainLV,
+                            false,
+                            0,
+                            false);
+    if(targetPluPV->CheckOverlaps()) {
+        G4String errormessage = "Overlap detected when placing targetPluPV for magnet \n"
+            "\t'" + magnetName + "' of type '" + magnetType + "'\n"
+            "\t, see error message above for more info.";
+        G4Exception("MagnetCOLLIMATORHV::Construct()", "MSDetConMagnet1001",FatalException,errormessage);
+    }
+    G4PVPlacement* targetMinPV =
+        new G4PVPlacement  (NULL,
+                            G4ThreeVector(isH?-offset:0.0,isH?0.0:-offset,0.0),
+                            targetMinLV,
+                            magnetName + "_targetMinPV",
+                            mainLV,
+                            false,
+                            0,
+                            false);
+    if(targetMinPV->CheckOverlaps()) {
+        G4String errormessage = "Overlap detected when placing targetMinPV for magnet \n"
+            "\t'" + magnetName + "' of type '" + magnetType + "'\n"
+            "\t, see error message above for more info.";
+        G4Exception("MagnetCOLLIMATORHV::Construct()", "MSDetConMagnet1001",FatalException,errormessage);
+    }
 
     ConstructDetectorLV();
     BuildMainPV_transform();

--- a/src/MagnetPBW.cc
+++ b/src/MagnetPBW.cc
@@ -98,14 +98,20 @@ void MagnetPBW::Construct() {
     pRot->rotateY(90.0*deg);
 
     G4LogicalVolume*  targetLV  = new G4LogicalVolume (targetSolid,targetMaterial, magnetName+"_targetLV");
-                                  new G4PVPlacement   (pRot,
+    G4PVPlacement*    targetPV  = new G4PVPlacement   (pRot,
                                                       G4ThreeVector(0.0,0.0,radius+5.0), //beam origin is 5mm before PBW
                                                       targetLV,
                                                       magnetName + "_targetPV",
                                                       mainLV,
                                                       false,
                                                       0,
-                                                      true);
+                                                      false);
+    if(targetPV->CheckOverlaps()) {
+        G4String errormessage = "Overlap detected when placing targetPV for magnet \n"
+            "\t'" + magnetName + "' of type '" + magnetType + "'\n"
+            "\t, see error message above for more info.";
+        G4Exception("MagnetPBW::Construct()", "MSDetConMagnet1001",FatalException,errormessage);
+    }
 
     G4VSolid*        waterSolid = new G4Tubs          (magnetName+"_waterS",
                                                       radius+1.25, radius+3.25, (length)/2.0,
@@ -113,7 +119,7 @@ void MagnetPBW::Construct() {
 
     G4LogicalVolume*    waterLV = new G4LogicalVolume (waterSolid,G4Material::GetMaterial("G4_WATER"),
                                                       magnetName + "_waterLV");
-                                  new G4PVPlacement   (NULL,
+    G4PVPlacement*      waterPV = new G4PVPlacement   (NULL,
                                                       G4ThreeVector(0.0,0.0,0.0),
                                                       waterLV,
                                                       magnetName + "_waterPV",
@@ -121,6 +127,12 @@ void MagnetPBW::Construct() {
                                                       false,
                                                       0,
                                                       true);
+    if(waterPV->CheckOverlaps()) {
+        G4String errormessage = "Overlap detected when placing waterPV for magnet \n"
+            "\t'" + magnetName + "' of type '" + magnetType + "'\n"
+            "\t, see error message above for more info.";
+        G4Exception("MagnetPBW::Construct()", "MSDetConMagnet1001",FatalException,errormessage);
+    }
 
     //Set color and line segments per circle for Visualization
     G4VisAttributes* aluminum = new G4VisAttributes(G4Colour(0.66,0.67,0.71));

--- a/src/MagnetPLASMA1.cc
+++ b/src/MagnetPLASMA1.cc
@@ -144,7 +144,7 @@ void MagnetPLASMA1::Construct() {
         exit(1);
     }
     G4LogicalVolume*   crystalLV = new G4LogicalVolume(crystalSolid,sapphireMaterial, magnetName+"_crystalLV");
-    //G4VPhysicalVolume* crystalPV =
+    G4VPhysicalVolume* crystalPV =
                                    new G4PVPlacement  (NULL,
                                                        G4ThreeVector(0.0,0.0,0.0),
                                                        crystalLV,
@@ -152,7 +152,13 @@ void MagnetPLASMA1::Construct() {
                                                        mainLV,
                                                        false,
                                                        0,
-                                                       true);
+                                                       false);
+    if(crystalPV->CheckOverlaps()) {
+        G4String errormessage = "Overlap detected when placing crystalPV for magnet \n"
+            "\t'" + magnetName + "' of type '" + magnetType + "'\n"
+            "\t, see error message above for more info.";
+        G4Exception("MagnetPLASMA1::Construct()", "MSDetConMagnet1001",FatalException,errormessage);
+    }
 
     ConstructDetectorLV();
     BuildMainPV_transform();

--- a/src/MagnetSHIELDEDSCINTILATOR.cc
+++ b/src/MagnetSHIELDEDSCINTILATOR.cc
@@ -142,20 +142,26 @@ void MagnetSHIELDEDSCINTILLATOR::Construct() {
     }
 
     // Scintillator
-    G4VSolid*         scintillatorSolid = new G4Tubs         (magnetName+"_scintS",
-                                                              0.0, r_scint, l_scint/2.0,
-                                                              0.0, 360.0*deg);
+    G4VSolid*          scintillatorSolid = new G4Tubs         (magnetName+"_scintS",
+                                                               0.0, r_scint, l_scint/2.0,
+                                                               0.0, 360.0*deg);
 
-                      scintillatorLV    = new G4LogicalVolume(scintillatorSolid,scintillatorMaterial, magnetName+"_scintLV");
+                       scintillatorLV    = new G4LogicalVolume(scintillatorSolid,scintillatorMaterial, magnetName+"_scintLV");
 
-                                          new G4PVPlacement  (NULL,
+    G4VPhysicalVolume* scintillatorPV    = new G4PVPlacement  (NULL,
                                                               G4ThreeVector(0.0,0.0,z_scint),
                                                               scintillatorLV,
                                                               magnetName + "_scintPV",
                                                               mainLV,
                                                               false,
                                                               0,
-                                                              true);
+                                                              false);
+    if(scintillatorPV->CheckOverlaps()) {
+        G4String errormessage = "Overlap detected when placing scintillatorPV for magnet \n"
+            "\t'" + magnetName + "' of type '" + magnetType + "'\n"
+            "\t, see error message above for more info.";
+        G4Exception("MagnetSHIELDEDSCINTILLATOR::Construct()", "MSDetConMagnet1001",FatalException,errormessage);
+    }
 
     //Shielding
     G4VSolid* shieldingCylOuter = new G4Tubs(magnetName+"_shieldingCylOuterS",
@@ -169,14 +175,20 @@ void MagnetSHIELDEDSCINTILLATOR::Construct() {
 
                     shieldingLV = new G4LogicalVolume(shieldingSolid, shieldingMaterial, magnetName+"_shieldingLV");
 
-                                  new G4PVPlacement(NULL,
+    G4PVPlacement* shieldingPV  = new G4PVPlacement(NULL,
                                                     G4ThreeVector(0.0,0.0,0.0),
                                                     shieldingLV,
                                                     magnetName+"shieldingPV",
                                                     mainLV,
                                                     false,
                                                     0,
-                                                    true);
+                                                    false);
+    if(shieldingPV->CheckOverlaps()) {
+        G4String errormessage = "Overlap detected when placing scintillatorPV for magnet \n"
+            "\t'" + magnetName + "' of type '" + magnetType + "'\n"
+            "\t, see error message above for more info.";
+        G4Exception("MagnetSHIELDEDSCINTILLATOR::Construct()", "MSDetConMagnet1001",FatalException,errormessage);
+    }
 
     //Other
     ConstructDetectorLV();

--- a/src/MagnetTARGET.cc
+++ b/src/MagnetTARGET.cc
@@ -93,15 +93,20 @@ void MagnetTARGET::Construct() {
     }
 
     G4LogicalVolume*   targetLV = new G4LogicalVolume(targetSolid,targetMaterial, magnetName+"_targetLV");
-    //G4VPhysicalVolume* targetPV =
-                                  new G4PVPlacement  (NULL,
+    G4VPhysicalVolume* targetPV = new G4PVPlacement  (NULL,
                                                       G4ThreeVector(0.0,0.0,0.0),
                                                       targetLV,
                                                       magnetName + "_targetPV",
                                                       mainLV,
                                                       false,
                                                       0,
-                                                      true);
+                                                      false);
+    if(targetPV->CheckOverlaps()) {
+        G4String errormessage = "Overlap detected when placing targetPV for magnet \n"
+            "\t'" + magnetName + "' of type '" + magnetType + "'\n"
+            "\t, see error message above for more info.";
+        G4Exception("MagnetTARGET::Construct()", "MSDetConMagnet1001",FatalException,errormessage);
+    }
 
     ConstructDetectorLV();
     BuildMainPV_transform();

--- a/src/MagnetTARGETR.cc
+++ b/src/MagnetTARGETR.cc
@@ -91,14 +91,20 @@ void MagnetTARGETR::Construct() {
     }
 
     G4LogicalVolume*   targetLV = new G4LogicalVolume(targetSolid,targetMaterial, magnetName+"_targetLV");
-                                  new G4PVPlacement  (NULL,
+    G4PVPlacement*     targetPV = new G4PVPlacement  (NULL,
                                                       G4ThreeVector(0.0,0.0,0.0),
                                                       targetLV,
                                                       magnetName + "_targetPV",
                                                       mainLV,
                                                       false,
                                                       0,
-                                                      true);
+                                                      false);
+    if(targetPV->CheckOverlaps()) {
+        G4String errormessage = "Overlap detected when placing targetPV for magnet \n"
+            "\t'" + magnetName + "' of type '" + magnetType + "'\n"
+            "\t, see error message above for more info.";
+        G4Exception("MagnetTARGETR::Construct()", "MSDetConMagnet1001",FatalException,errormessage);
+    }
 
     ConstructDetectorLV();
     BuildMainPV_transform();


### PR DESCRIPTION
Explicitly call the overlaps checking code and abort if overlap is detected (don't just emit an error message).
